### PR TITLE
Add module header to documentation

### DIFF
--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE QuasiQuotes        #-}
 {-# LANGUAGE RecordWildCards    #-}
 
+{-| This modules provides a basic library API to @nix-delegate@'s functionality
+-}
+
 module Nix.Delegate
     ( -- * Options
       OptArgs(..)


### PR DESCRIPTION
... because I'm always obsessed with 100% documentation coverage