### PR TITLE
Add version bounds to `base`

### DIFF
--- a/nix-delegate.cabal
+++ b/nix-delegate.cabal
@@ -12,7 +12,7 @@ Synopsis: Convenient utility for distributed Nix builds
 Library
     Hs-Source-Dirs: src
     Exposed-Modules: Nix.Delegate
-    Build-Depends: base
+    Build-Depends: base                 >= 4.7.0.0  && < 5
                  , neat-interpolation                  < 0.4
                  , optparse-applicative >= 0.13.2.0 && < 0.15
                  , foldl                               < 1.4


### PR DESCRIPTION
This sets the lower bound to `base-4.7.0.0` because that's how far back the
change log currently goes:

https://hackage.haskell.org/package/base-4.10.0.0/changelog