### PR TITLE
Fix check for `nix-build` executable

### DIFF
--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -137,8 +137,9 @@ renderCmd :: Command -> Text
 renderCmd (Command cmd args) = Turtle.format (s%" "%s) cmd (Data.Text.intercalate " " args)
 
 canSudo :: Command -> Bool
-canSudo (Command "nix-build" _) = True
-canSudo _                       = False
+canSudo (Command command _) = Turtle.filename path == "nix-build"
+  where
+    path = Turtle.fromText command
 
 -- | @main@ used by the @delegate@ executable
 main :: IO ()


### PR DESCRIPTION
The `canSudo` function only enables `sudo` for `nix-build` invocations but the
check fails if you use a fully-qualified `nix-build` executable (such as
`/nix/store/...-nix/bin/nix-build`).  This changes the check to match against
the file name instead of the entire command path