### PR TITLE
Fix typo

### DIFF
--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -336,7 +336,7 @@ delegateShared OptArgs{..}  = do
         initiating the build and therefore the @root@ user needs to authorize
         the known host
     -}
-    Turtle.err "[+} Testing SSH access"
+    Turtle.err "[+] Testing SSH access"
     let testSSH = s%" ssh -i "%fp%" "%s%" :"
     Turtle.shells (Turtle.format testSSH sudo key' host') Turtle.empty
 


### PR DESCRIPTION
A newly added error message used `[+}` instead of `[+]`, which this
change fixes