### PR TITLE
Nix.Delegate: do not use haddock syntax in a comment as haddock fails

### DIFF
--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE QuasiQuotes        #-}
 {-# LANGUAGE RecordWildCards    #-}
 
-{-| This modules provides a basic library API to @nix-delegate@'s functionality
+{-| This module provides a basic library API to @nix-delegate@'s functionality
 -}
 
 module Nix.Delegate

--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -324,7 +324,7 @@ delegateShared OptArgs{..}  = do
             Just user -> return (user <> "@" <> host)
       else return host
 
-    {-| Do a test @ssh@ command in order to prompt the user to recognize the
+    {-  Do a test @ssh@ command in order to prompt the user to recognize the
         host if the host is not known
 
         Use @sudo@ if we are in multi-user mode since the @root@ user will be


### PR DESCRIPTION
Tested using `nix-build release.nix`.

It looks like nix-delegate does not enforce a version of nixpkgs, so mine is `18.03pre128481.1098c071e59`.

While here, fix a typo.