### PR TITLE
If the keys have not changed, then avoid sudo.

### DIFF
--- a/nix-delegate.cabal
+++ b/nix-delegate.cabal
@@ -13,6 +13,7 @@ Library
     Hs-Source-Dirs: src
     Exposed-Modules: Nix.Delegate
     Build-Depends: base                 >= 4.7.0.0  && < 5
+                 , bytestring           >= 0.10.8.1 && < 1.0
                  , neat-interpolation                  < 0.4
                  , optparse-applicative >= 0.13.2.0 && < 0.15
                  , foldl                               < 1.4


### PR DESCRIPTION
As a convenience, here is a whitespace-ignoring diff:
```
$ git diff -b master
diff --git a/src/Nix/Delegate.hs b/src/Nix/Delegate.hs
index cf2af92..0f6ec6d 100644
--- a/src/Nix/Delegate.hs
+++ b/src/Nix/Delegate.hs
@@ -260,6 +260,16 @@ exchangeKeys key host = do
 
           liftIO (Control.Exception.handle handler1 download)
 
+          ec <- Turtle.proc "cmp"
+              [ "-s"
+              , Turtle.format fp localPath
+              , Turtle.format fp path
+              ] empty
+          case ec of
+              ExitSuccess -> do
+                  let same = Turtle.format ("[+] Unchanged: "%fp) path
+                  mapM_ Turtle.err (Turtle.Line.textToLines same)
+              _ -> do
                   -- NB: path shouldn't is a FilePath and won't have any
                   -- newlines, so this should be okay
                   Turtle.err (Turtle.unsafeTextToLine $ Turtle.format ("[+] Installing: "%fp) path)
```
