### PR TITLE
Increase upper bound on `foldl` and `turtle`

### DIFF
--- a/nix-delegate.cabal
+++ b/nix-delegate.cabal
@@ -16,10 +16,10 @@ Library
                  , bytestring           >= 0.10.8.1 && < 1.0
                  , neat-interpolation                  < 0.4
                  , optparse-applicative >= 0.13.2.0 && < 0.15
-                 , foldl                               < 1.4
+                 , foldl                               < 1.5
                  , managed              >= 1.0.3    && < 1.1
                  , text                                < 1.3
-                 , turtle               >= 1.3.0    && < 1.5
+                 , turtle               >= 1.3.0    && < 1.6
     GHC-Options: -Wall
 
 Executable nix-delegate


### PR DESCRIPTION
Related to https://github.com/NixOS/nixpkgs/issues/49709